### PR TITLE
add file name argument to generate_initial_state with error checks

### DIFF
--- a/Day_1/day_1.py
+++ b/Day_1/day_1.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
@@ -5,15 +6,25 @@ from mpl_toolkits.mplot3d import Axes3D
 
 # Generate initial state
 
-def generate_initial_state(num_particles, box_length, method='random'):
+def generate_initial_state(num_particles, box_length, method='random', fname=None):
 
     if method is 'random':
         # Randomly placing particles in a box
         coordinates = (0.5 - np.random.rand(num_particles, 3)) * box_length
-        
+    
     elif method is 'file':
-        # Reading a reference configuration from NIST
-        coordinates = np.loadtxt("lj_sample_config_periodic1.txt", skiprows=2, usecols=(1,2,3))
+        try:
+            # Reading a reference configuration from NIST
+            coordinates = np.loadtxt(fname, skiprows=2, usecols=(1,2,3))
+        except ValueError:
+            if fname is None:
+                raise ValueError("generate_initial_state: Method set to 'file', but no filepath given. Please specify an input file")
+            else:
+                raise ValueError
+        except OSError:
+            raise OSError(F'File {fname} not found.')
+        except:
+            raise TypeError(F'Could not read file {fname} - incompatible file format for input coordinates.')
     
     return coordinates
 
@@ -150,6 +161,8 @@ tune_displacement = True
 # Simulation initialization
 # -------------------------
 
+file_name = os.path.join('..', 'nist_sample_config1.txt')
+
 element = 'C'
 beta = 1 / reduced_temperature
 box_length = np.cbrt(num_particles / reduced_density)
@@ -158,7 +171,7 @@ cutoff2 = np.power(cutoff, 2)
 n_trials = 0
 n_accept = 0
 energy_array = np.zeros(n_steps)
-coordinates = generate_initial_state(num_particles, box_length, method='random')
+coordinates = generate_initial_state(num_particles, box_length, method='file', fname=file_name)
 total_pair_energy = total_potential_energy(coordinates, box_length)
 tail_correction = tail_correction(box_length)
 traj = open('traj.xyz', 'w') 

--- a/Day_1/day_1.py
+++ b/Day_1/day_1.py
@@ -6,6 +6,49 @@ from mpl_toolkits.mplot3d import Axes3D
 
 # Generate initial state
 
+def generate_initial_state_2(method, **kwargs):
+    if method != "random" and method != "file":
+        raise ValueError(F'Unknown method {method} specified. Options are "random" or "file"')
+    
+    # Check inputs - this dictionary gives expected kwargs for each method.
+    expected_kwargs = {
+        "random": ['num_particles', 'box_length'],
+        "file": ["fname"],
+    }
+    
+    expected_keys = expected_kwargs[method]
+    input_keys = list(kwargs.keys())
+    
+    ## Check that we only have expected arguments in kwargs
+    list_diff = np.setdiff1d(input_keys, expected_keys)
+    if list_diff:
+        raise TypeError(F'Arguments {list_diff} not recognized for method="{method}"". Valid inputs are {expected_keys}')
+
+    ## Check that we have all expected  arguments in kwargs
+    list_diff = np.setdiff1d(expected_keys, input_keys)
+    if list_diff:
+        raise TypeError(F'Missing argument {list_diff} for input method {method}.')
+    
+    if method == "random":
+        # Generate state based on inputs
+        num_particles = kwargs['num_particles']
+        box_length = kwargs['box_length']
+        coordinates = (0.5 - np.random.rand(num_particles, 3)) * box_length
+    else:
+        # Else, method is file.
+        fname = kwargs['fname']
+        # Try reading the file
+        try:
+            # Reading a reference configuration from NIST
+            coordinates = np.loadtxt(fname, skiprows=2, usecols=(1,2,3))
+        except OSError:
+            raise OSError(F'File {fname} not found.')
+        except Exception as e:
+            print(e)
+            raise
+    return coordinates
+            
+
 def generate_initial_state(method='random', fname=None, num_particles=None, box_length=None):
 
     if method is 'random':
@@ -27,10 +70,12 @@ def generate_initial_state(method='random', fname=None, num_particles=None, box_
                 raise ValueError
         except OSError:
             raise OSError(F'File {fname} not found.')
-        except:
-            raise TypeError(F'Could not read file {fname} - incompatible file format for input coordinates.')
+        except Execption as e:
+            print(e)
+            raise
     
     return coordinates
+    
 
 # Lennard Jones potential implementation
 
@@ -57,7 +102,6 @@ def total_potential_energy(coordinates, box_length):
 
     for i_particle in range(num_particles):
         for j_particle in range(i_particle):
-
             r_i = coordinates[i_particle]
             r_j = coordinates[j_particle]
             rij2 = minimum_image_distance(r_i, r_j, box_length)
@@ -148,82 +192,81 @@ def update_output_file(traj, i_step, freq, element, num_particles, coordinates):
         for i_particle in range(num_particles):
             traj.write("%s %10.5f %10.5f %10.5f \n" % (element, coordinates[i_particle][0], coordinates[i_particle][1], coordinates[i_particle][2]))
 
+if __name__ == "__main__":
+        
+    # ---------------
+    # Parameter setup
+    # ---------------
 
-# ---------------
-# Parameter setup
-# ---------------
+    reduced_density = 0.9
+    reduced_temperature = 0.9
+    max_displacement = 0.1
+    n_steps = 50000
+    freq = 1000
+    tune_displacement = True
 
-reduced_density = 0.9
-reduced_temperature = 0.9
-max_displacement = 0.1
-n_steps = 50000
-freq = 1000
-tune_displacement = True
+    beta = 1 / reduced_temperature
 
-beta = 1 / reduced_temperature
+    # -------------------------
+    # Simulation initialization
+    # -------------------------
 
-# -------------------------
-# Simulation initialization
-# -------------------------
+    # Coordinate initialization
+    method = 'file'
+    element = 'C'
 
-# Coordinate initialization
-method = 'file'
-element = 'C'
-
-if method == 'random':
-    num_particles = 100
-    box_length = np.cbrt(num_particles / reduced_density)
-    coordintes = generate_initial_state(method=method, num_particles=num_particles, box_length=box_length)
-else:
-    file_name = os.path.join('..', 'nist_sample_config1.txt')
-    coordinates = generate_initial_state(method=method, fname=file_name)
-    num_particles = len(coordinates)
-    with open(file_name) as f:
-        f.readline()
-        box_length = float(f.readline().split()[0])
-
-cutoff = box_length / 2.0
-cutoff2 = np.power(cutoff, 2)
-n_trials = 0
-n_accept = 0
-energy_array = np.zeros(n_steps)
-coordinates = generate_initial_state(method=method, fname=file_name)
-
-
-total_pair_energy = total_potential_energy(coordinates, box_length)
-tail_correction = tail_correction(box_length)
-print(total_pair_energy)
-
-traj = open('traj.xyz', 'w') 
-
-# --------------------------------
-# Metropolis Monte Carlo algorithm
-# --------------------------------
-
-for i_step in range(n_steps):
-
-    n_trials += 1
-
-    delta_e, i_particle, old_position, coordinates = move_particle(num_particles, max_displacement, coordinates)
-
-    accept = accept_or_reject(delta_e, beta)
-
-    if accept:
-        total_pair_energy += delta_e
-        n_accept += 1
+    if method == 'random':
+        num_particles = 100
+        box_length = np.cbrt(num_particles / reduced_density)
+        coordintes = generate_initial_state_2(method=method, num_particles=num_particles, box_length=box_length)
     else:
-        coordinates = restore_system(coordinates, i_particle, old_position)
+        file_name = os.path.join('..', 'nist_sample_config1.txt')
+        coordinates = generate_initial_state_2(method=method, fname=file_name)
+        num_particles = len(coordinates)
+        with open(file_name) as f:
+            f.readline()
+            box_length = float(f.readline().split()[0])
 
-    if tune_displacement:
-        max_displacement = adjust_displacement(freq, i_step, n_trials, n_accept, max_displacement)
+    cutoff = 3.0
+    cutoff2 = np.power(cutoff, 2)
+    n_trials = 0
+    n_accept = 0
+    energy_array = np.zeros(n_steps)
 
-    total_energy = (total_pair_energy + tail_correction) / num_particles
+    total_pair_energy = total_potential_energy(coordinates, box_length)
+    tail_correction = tail_correction(box_length)
+    print(total_pair_energy)
 
-    energy_array[i_step] = total_energy
+    traj = open('traj.xyz', 'w') 
 
-    update_output_file(traj, i_step, freq, element, num_particles, coordinates)
+    # --------------------------------
+    # Metropolis Monte Carlo algorithm
+    # --------------------------------
 
-    if np.mod(i_step + 1, 1000) == 0:
-        print (i_step + 1, energy_array[i_step])
+    for i_step in range(n_steps):
 
-traj.close()
+        n_trials += 1
+
+        delta_e, i_particle, old_position, coordinates = move_particle(num_particles, max_displacement, coordinates)
+
+        accept = accept_or_reject(delta_e, beta)
+
+        if accept:
+            total_pair_energy += delta_e
+            n_accept += 1
+        else:
+            coordinates = restore_system(coordinates, i_particle, old_position)
+
+        if tune_displacement:
+            max_displacement = adjust_displacement(freq, i_step, n_trials, n_accept, max_displacement)
+
+        total_energy = (total_pair_energy + tail_correction) / num_particles
+
+        energy_array[i_step] = total_energy
+
+        update_output_file(traj, i_step, freq, element, num_particles, coordinates)
+
+        if np.mod(i_step + 1, 1000) == 0:
+            print (i_step + 1, energy_array[i_step])
+
+    traj.close()


### PR DESCRIPTION
This PR addresses #7 - a default file name of 'None' is added (the default method is 'random', so no file name would be needed).

The function performs checks using a 'try' statement if the method is file. Errors are raised if the file is not set (ie, the fname is None), if the file is not found, or if the file is not a coordinate fie.

`num_particles` and `box_length` are now also named parameters. If the `method` is file, `num_particles` and `box_length` is determined by what is in the file, so should not be passed for the `file` method.

**Edit**
Added second function `generate_initial_state_2` which uses kwargs.